### PR TITLE
Buf Fix : Remove whitespaces in enum strings value.

### DIFF
--- a/scripts/make_library.py
+++ b/scripts/make_library.py
@@ -78,7 +78,7 @@ class EnumerationType:
 
     def make_assignations(self, f, className):
         if(self.type == 'string'):
-            f.write('  const std::string %s::%s = "%s";\n' % (className, self.name, self.value))
+            f.write('  const std::string %s::%s = "%s";\n' % (className, self.name, self.value.replace(" ","")))
 
 class PrimitiveDataType:
     """ Our datatype is a C/C++ primitive. """


### PR DESCRIPTION
If the definition message contain white space in enumerate string, white space was propagated to enumarate value in C++.

As an example, if msg file is : 
`string TOTO = toto`
This will create the following c++ const string : 
`string TOTO = " toto"`

With this Fix, white spaces are removed in the const string value.
